### PR TITLE
ansible-lint requires a version of Ansible package >= 2.9, but none w…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible-lint
+        run: pip3 install yamllint ansible-lint ansible
 
       - name: Lint code.
         run: |


### PR DESCRIPTION
…as found